### PR TITLE
Add CINO project tracker provenance metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+```
+project_tracker_base: CINO Project Tracker:appf7fRQUvY9Iy7sL
+project_tracker_table: Projects:tblchmbxSAavvJKaY
+project_tracker_record: SecID-Server-API:reccvS9lgX0bJaKWe
+project_source: github:CloudSecurityAlliance-Internal/CINO-Projects/projects/SecID-Server-API
+```
+
 # SecID-Server-API
 
 Self-hosted SecID resolver — run your own API server locally, in Docker, or on internal infrastructure.


### PR DESCRIPTION
## Summary

- Adds `project_tracker_record:` metadata block to `README.md` per the CINO-Project-Management plugin spec
- Block lets any AI/human reading the README trace back to the Airtable record (`reccvS9lgX0bJaKWe`) without prior context
- Part of a coordinated alignment across the four SecID repos

## Test plan

- [ ] Visual: README renders with the metadata block as a fenced code block above the title
- [ ] Block contents match the Airtable record ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)