### PR TITLE
resolver: import SECID_TYPES from registry_loader (dedup)

### DIFF
--- a/python/resolver.py
+++ b/python/resolver.py
@@ -8,6 +8,7 @@ import json
 import re
 from typing import Optional
 
+from registry_loader import SECID_TYPES
 from storage import Store
 
 # Format metadata fields lifted from child data to top-level result
@@ -19,12 +20,6 @@ def _add_format_metadata(result: dict, data: dict) -> None:
     for field in _FORMAT_METADATA_FIELDS:
         if data.get(field):
             result[field] = data[field]
-
-
-SECID_TYPES = [
-    "advisory", "capability", "control", "disclosure", "entity",
-    "methodology", "reference", "regulation", "ttp", "weakness",
-]
 
 
 def resolve(store: Store, secid_query: str, registry_dirs: list[str] = None) -> dict:


### PR DESCRIPTION
## Summary
\`SECID_TYPES\` was defined twice in \`python/\` — once in \`registry_loader.py\` (lines 21-24) and once in \`resolver.py\` (lines 24-27), each as a literal 10-name array. \`secid_server.py\` already imports \`SECID_TYPES\` from \`registry_loader\`; \`resolver.py\` now does the same instead of redefining.

## Why this matters
When a new SecID type is added in the future, the type list has to be updated in every hardcoded location. Keeping two literals in the same \`python/\` package was unnecessary maintenance burden. Now it's just one literal in \`registry_loader.py\`, imported by both other modules.

## Test plan
- [x] \`python3 -c "from resolver import SECID_TYPES; print(SECID_TYPES)"\` returns all 10 expected types
- [x] \`python3 -c "import secid_server"\` still loads cleanly
- [x] No other file in \`python/\` references \`SECID_TYPES\` from \`resolver\` (the import direction is from \`registry_loader\` outward)

## Out of scope
Reducing duplication across **repositories** (the type list also appears in SecID-Service's \`type-registry.ts\`, SecID's \`schemas/registry-namespace.schema.json\` enum, and SecID's various .md docs). Those will continue to require coordinated updates when a new type is added. This PR only deduplicates within this repo's \`python/\` package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)