### PR TITLE
ci: add Python smoke tests and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Test
+
+# Runs the test suite for the self-hosted Python resolver.
+#
+# Currently covers smoke tests only — verifying imports, the canonical
+# 10-type list, and basic resolve() invariants. Fuller coverage (parser,
+# resolver semantics, integration with a real registry) will land as the
+# conformance suite work in SecID-Client-SDK matures and gets ported.
+#
+# TypeScript and Go implementations are README-stubs today; their CI jobs
+# will be added when those implementations land.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  python:
+    name: Python
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run smoke tests
+        run: pytest test_smoke.py -v

--- a/python/test_smoke.py
+++ b/python/test_smoke.py
@@ -1,0 +1,84 @@
+"""Smoke tests — verify the core resolver modules import cleanly and basic
+constants/behavior are sane.
+
+This is intentionally minimal: import-level guarantees plus a couple of
+sanity assertions. Full test coverage will come with the conformance suite
+work tracked in SecID-Client-SDK.
+
+Note: deliberately does NOT import secid_server.py — that module runs
+argparse + storage initialization at import time, which makes it untestable
+without restructuring. A future PR will move its CLI bootstrap into a
+main() function gated by `if __name__ == "__main__":`.
+"""
+
+import pytest
+
+
+def test_resolver_module_imports():
+    """resolver.py is the core resolution logic; must import without side effects."""
+    from resolver import resolve, SECID_TYPES
+    assert callable(resolve)
+    assert isinstance(SECID_TYPES, list)
+
+
+def test_registry_loader_module_imports():
+    """registry_loader.py owns SECID_TYPES and the bulk_load function."""
+    from registry_loader import SECID_TYPES, bulk_load
+    assert callable(bulk_load)
+    assert isinstance(SECID_TYPES, list)
+
+
+def test_storage_module_imports():
+    """storage.py provides the pluggable Store abstraction."""
+    from storage import create_store, Store
+    assert callable(create_store)
+
+
+def test_secid_types_canonical():
+    """The 10 official SecID types — frozen at v1.0, must not drift silently."""
+    from registry_loader import SECID_TYPES
+    expected = {
+        "advisory", "capability", "control", "disclosure", "entity",
+        "methodology", "reference", "regulation", "ttp", "weakness",
+    }
+    assert set(SECID_TYPES) == expected, (
+        f"Type list drift detected. "
+        f"Missing: {expected - set(SECID_TYPES)}. "
+        f"Extra: {set(SECID_TYPES) - expected}."
+    )
+    assert len(SECID_TYPES) == 10
+
+
+def test_secid_types_single_source():
+    """Confirm resolver.py imports SECID_TYPES from registry_loader rather
+    than redefining it (PR #4 dedup)."""
+    import resolver
+    import registry_loader
+    assert resolver.SECID_TYPES is registry_loader.SECID_TYPES, (
+        "resolver.SECID_TYPES should be the same object as "
+        "registry_loader.SECID_TYPES (imported, not redefined). "
+        "If they differ, the dedup from PR #4 has regressed."
+    )
+
+
+def test_resolve_handles_empty_input():
+    """resolve() must not crash on edge inputs — minimum contract."""
+    from resolver import resolve
+    from storage import create_store
+
+    store = create_store("memory")
+    result = resolve(store, "")
+    assert isinstance(result, dict)
+    # Empty input should produce an error envelope, not raise.
+    assert "secid_query" in result or "error" in result or "results" in result
+
+
+def test_resolve_handles_missing_prefix():
+    """A SecID without the 'secid:' prefix is malformed; must return an error envelope."""
+    from resolver import resolve
+    from storage import create_store
+
+    store = create_store("memory")
+    result = resolve(store, "advisory/mitre.org/cve#CVE-2021-44228")
+    assert isinstance(result, dict)
+    # Should produce SOME response, not raise.


### PR DESCRIPTION
## Summary
First CI for this repo. Adds smoke tests for the testable core modules and a Python-matrix workflow that runs them on every PR and push to main.

Part of a broader "make SecID production-mature before traction" initiative — earlier PRs landed CI in SecID-Client-SDK; this is the equivalent here.

## Smoke test coverage (\`python/test_smoke.py\`)
7 tests, all passing locally:
- All three core modules (\`resolver\`, \`registry_loader\`, \`storage\`) import cleanly
- \`SECID_TYPES\` is the canonical 10-name list (catches type-list drift)
- PR #4's dedup is preserved (\`resolver.SECID_TYPES is registry_loader.SECID_TYPES\`)
- \`resolve()\` handles empty and malformed inputs without raising

## Known limitation
\`secid_server.py\` is NOT imported by the smoke tests. It runs \`argparse.parse_known_args()\` and storage initialization at module import time, which would cause pytest to either crash or load a host-specific registry path. A follow-up PR will move CLI bootstrap behind an \`if __name__ == "__main__":\` guard so the module becomes testable. That PR will also let us add real integration tests for the HTTP API.

## Matrix
- Python: 3.10, 3.11, 3.12, 3.13 (3.9 dropped — \`fastapi>=0.115\` requires 3.10+)

## Security review
- No \`github.event.*\` interpolation
- Matrix values are literals
- \`permissions: contents: read\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)