### PR TITLE
docs: position Python as reference implementation, document optional MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,11 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- `python/` is the active server implementation (`secid_server.py`, resolver, loader, storage).
-- `tests/` and `docker/` currently document planned shared test/deployment flows.
-- `typescript/` is a placeholder for the planned Node implementation.
+- `python/` is the active reference implementation (`secid_server.py` factory + CLI, resolver, loader, storage). Includes `test_smoke.py`.
+- `typescript/` and `go/` are placeholders for the planned production-throughput implementations.
+- `tests/` documents the planned shared conformance suite (fixtures live in `SecID-Client-SDK`).
+- `docker/` documents planned containerization.
+- `.github/workflows/test.yml` runs the Python smoke suite on every PR.
 - Repository root docs describe self-hosting, storage modes, and compatibility with the hosted service.
 
 ## Build, Test, and Development Commands
@@ -21,9 +23,10 @@ Run from repository root unless noted.
 - Keep API response shape compatible with `SecID-Service` (`found`, `corrected`, `related`, `not_found`, `error`).
 
 ## Testing Guidelines
-- This repo does not yet ship a full automated suite; rely on reproducible smoke tests per change.
-- Validate `/health`, `/api/v1/resolve`, and `/admin/reload` when touching server internals.
+- `python/test_smoke.py` covers imports, the factory, basic HTTP endpoints, and type-list invariants. Run with `pytest test_smoke.py -v` from `python/`.
+- For new HTTP endpoints, add a test using `fastapi.testclient.TestClient` against `create_app(ServerConfig(...))`. See the existing endpoint tests for the pattern.
 - For resolver logic changes, compare outputs against the hosted service for representative SecIDs.
+- Conformance against the canonical SecID-Service is the broader goal — the shared fixture suite lives in `SecID-Client-SDK/tests/fixtures.json` and is being grown into a multi-implementation conformance gate.
 
 ## Commit & Pull Request Guidelines
 - Use imperative commit subjects and keep commits focused by subsystem.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,21 +6,26 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Self-hosted SecID resolver — run your own API server for resolving security knowledge identifiers. Part of the [SecID ecosystem](https://github.com/CloudSecurityAlliance/SecID).
 
-Two implementations (Python reference + TypeScript) serve the same API as the production service at [secid.cloudsecurityalliance.org](https://secid.cloudsecurityalliance.org/).
+Three implementations planned: **Python (the reference implementation)**, plus TypeScript and Go (both planned). Each serves the same REST API as the production service at [secid.cloudsecurityalliance.org](https://secid.cloudsecurityalliance.org/).
+
+The Python implementation also exposes an **optional MCP endpoint** at `/mcp` (requires `pip install mcp`). It's the reference implementation specifically because it demonstrates every server-side feature: REST API, MCP endpoint, pluggable storage backends, lazy/bulk loading, registry overlays. TS/Go implementations will be production-throughput-focused and serve REST only — the canonical MCP surface remains SecID-Service.
 
 ## Repository Structure
 
 ```
 SecID-Server-API/
 ├── python/                  # Python reference implementation
-│   ├── secid_server.py      # FastAPI server (/api/v1/resolve + /mcp)
+│   ├── secid_server.py      # FastAPI factory + CLI (/api/v1/resolve + optional /mcp)
 │   ├── resolver.py          # Core resolution logic
 │   ├── registry_loader.py   # Load strategies (bulk, lazy, update)
 │   ├── storage.py           # Storage backends (memory, Redis, memcached, SQLite)
+│   ├── test_smoke.py        # Smoke + factory + HTTP endpoint tests
 │   └── requirements.txt
 ├── typescript/              # TypeScript implementation (planned)
+├── go/                      # Go implementation (planned)
 ├── docker/                  # Dockerfile and compose (planned)
-├── tests/                   # Shared test suite — any server should pass these (planned)
+├── tests/                   # Shared conformance suite — fixtures live in SecID-Client-SDK
+├── .github/workflows/       # CI: runs pytest on the Python matrix
 ├── README.md
 └── CLAUDE.md
 ```
@@ -47,8 +52,10 @@ curl http://localhost:8000/health
 
 ## Key Design Decisions
 
+- **Factory pattern**: `secid_server.create_app(config)` returns a configured FastAPI app with no module-level side effects. Tests use it via `fastapi.testclient.TestClient`; ASGI deployments use it to construct apps from environment variables. The CLI in `main()` is a thin wrapper that builds a `ServerConfig` from argparse and calls the factory.
 - **Pluggable storage**: All backends implement `get(key) → str | None` and `set(key, value)`. Registry data is read-only at runtime.
 - **Same API**: `/api/v1/resolve` returns the same envelope as SecID-Service. Any SecID client works with any server.
+- **Optional MCP**: `/mcp` mounted only if `pip install mcp` was run. Gracefully no-ops otherwise. The Python implementation is positioned as the reference that demonstrates MCP integration; the TS/Go ports (when built) will be REST-only since the canonical MCP surface is SecID-Service.
 - **Multiple registries**: `--registry` can be specified multiple times. Later directories overlay earlier ones (private data supplements public).
 - **Loading strategies**: Lazy (default, instant startup), bulk (load all at startup), update (reload changed files after git pull).
 - **Format metadata on results**: Resolution results include optional `parsability` (`structured`/`scraped`), `schema` (SecID reference), `parsing_instructions` (SecID reference), `auth` (free text), and `content_type` (MIME type) fields. These describe what data format you get at each URL. The `?parsability=structured` query parameter filters for machine-readable sources only.

--- a/README.md
+++ b/README.md
@@ -12,14 +12,15 @@ Self-hosted SecID resolver — run your own API server locally, in Docker, or on
 - **Federation** — register your resolver in the SecID ecosystem so others can discover it
 - **Customization** — extend the resolver, add auth, integrate with internal systems
 
-## Two Implementations
+## Implementations
 
-| Implementation | Language | Best for |
-|---------------|----------|----------|
-| **Python** | Python 3.10+ | Quick start, reference implementation, easy to extend |
-| **TypeScript** | Node.js 22+ | Closest to production SecID-Service, higher throughput |
+| Implementation | Status | Language | Best for |
+|---------------|--------|----------|----------|
+| **Python** | Active | Python 3.10+ | **Reference implementation** — shows all the moving parts (REST API + MCP + pluggable storage). Optimized for clarity and ease of extension; read the code to understand SecID server-side. |
+| **TypeScript** | Planned | Node.js 22+ | Production-grade throughput; closest shape to SecID-Service's Cloudflare Worker. |
+| **Go** | Planned | Go 1.22+ | Production-grade throughput; single static binary for deployment. |
 
-Both serve the same API, pass the same test suite, and support the same storage backends.
+All implementations serve the same REST API, pass the same conformance suite, and support the same storage backends. The Python implementation additionally exposes an optional MCP endpoint — see below.
 
 ## Quick Start (Python)
 
@@ -90,13 +91,23 @@ Same response format, same status values (`found`, `corrected`, `related`, `not_
 
 Resolution results may include optional format metadata fields: `parsability`, `schema`, `parsing_instructions`, `auth`, and `content_type`. Use `?parsability=structured` to filter for machine-readable sources. See the [SecID API Response Format](https://github.com/CloudSecurityAlliance/SecID/blob/main/docs/reference/API-RESPONSE-FORMAT.md) for details.
 
-### MCP Endpoint
+### MCP Endpoint (optional)
 
 ```
 /mcp
 ```
 
-Point any MCP client at your self-hosted server. Same three tools: `resolve`, `lookup`, `describe`.
+Point any MCP client at your self-hosted server. Same three tools as SecID-Service: `resolve`, `lookup`, `describe`.
+
+MCP support requires the `mcp` Python package:
+
+```bash
+pip install mcp
+```
+
+Without it, the server starts normally and serves the REST API; the `/mcp` endpoint is logged as "disabled" at startup. This keeps the MCP dependency optional for users who only need the REST API.
+
+The Python implementation is currently the only one with MCP support — TS/Go implementations (when built) will serve REST only. The canonical production MCP surface remains [SecID-Service](https://secid.cloudsecurityalliance.org/mcp).
 
 ## Private Registry Data
 


### PR DESCRIPTION
## Summary
Documentation-only PR following decisions from the testing-maturity discussion:

- Python implementation positioned as the **reference implementation** (shows REST API + MCP + pluggable storage) — TS and Go (planned) will be production-throughput-focused and serve REST only.
- The optional MCP endpoint is now explicitly documented. Requires \`pip install mcp\`; the server starts normally without it and the \`/mcp\` endpoint is logged as disabled.
- Three planned implementations (Python active, TypeScript + Go planned) replaces the prior two-impl framing.
- CLAUDE.md and AGENTS.md updated to reflect the factory pattern (post PR #6) and existing test/CI infrastructure.

## Files changed
- \`README.md\` — Implementations table now lists three; MCP section spells out optional \`pip install mcp\` requirement and positioning
- \`CLAUDE.md\` — Project overview, repo structure, and Key Design Decisions reflect factory pattern + optional MCP
- \`AGENTS.md\` — Removed stale "no automated suite" line; Project Structure mentions test_smoke.py + CI workflow

No code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)