### PR TITLE
fix: contain registry path resolution against traversal (F-05-01)

### DIFF
--- a/python/registry_loader.py
+++ b/python/registry_loader.py
@@ -24,6 +24,39 @@ SECID_TYPES = [
 ]
 
 
+def _reject_unsafe_segment(value: Optional[str]) -> bool:
+    """Return True if a namespace/subpath segment is unsafe to join into a path.
+
+    Rejects parent-dir traversal ('..'), absolute paths, backslashes, and NUL.
+    Namespace/subpath segments are derived from the untrusted query string, and
+    pathlib's '/' join does NOT collapse '..', so a crafted namespace could
+    otherwise escape the registry tree (arbitrary .json read / existence oracle).
+    """
+    if not value:
+        return False
+    if "\x00" in value or "\\" in value:
+        return True
+    if value.startswith("/"):
+        return True
+    return any(part == ".." for part in value.split("/"))
+
+
+def _contained_path(registry_dir: str, full_path: Path) -> Optional[Path]:
+    """Return full_path iff it resolves inside registry_dir, else None.
+
+    Resolves symlinks and collapses '..' on both sides, then confirms the
+    target stays within the registry root. Fails closed (None) on escape or
+    any resolution error, so callers treat it as 'file not present'.
+    """
+    try:
+        base = Path(registry_dir).resolve()
+        target = full_path.resolve()
+        target.relative_to(base)  # raises ValueError if outside base
+    except (ValueError, OSError):
+        return None
+    return target
+
+
 def find_registry_json_files(registry_dirs: list[str]) -> list[Path]:
     """Find all .json registry files across one or more registry directories.
 
@@ -88,8 +121,8 @@ def build_type_index(store: Store, registry_dirs: list[str]) -> None:
         # Load type-level JSON if it exists
         type_json = None
         for registry_dir in registry_dirs:
-            type_file = Path(registry_dir) / f"{secid_type}.json"
-            if type_file.exists():
+            type_file = _contained_path(registry_dir, Path(registry_dir) / f"{secid_type}.json")
+            if type_file and type_file.exists():
                 type_json = json.loads(type_file.read_text())
                 break
 
@@ -144,6 +177,11 @@ def bulk_load(store: Store, registry_dirs: list[str]) -> int:
 
 def load_single(store: Store, registry_dirs: list[str], secid_type: str, namespace: str) -> Optional[dict]:
     """Lazy load a single namespace entry. Returns the data or None."""
+    # Reject hostile namespaces before they reach the filesystem join.
+    if _reject_unsafe_segment(namespace):
+        logger.warning(f"Rejected unsafe namespace: {namespace!r}")
+        return None
+
     # Convert namespace to filesystem path: redhat.com → com/redhat.json
     parts = namespace.split("/", 1)
     domain = parts[0]
@@ -157,8 +195,10 @@ def load_single(store: Store, registry_dirs: list[str], secid_type: str, namespa
     fs_path += ".json"
 
     for registry_dir in reversed(registry_dirs):  # later dirs take priority
-        full_path = Path(registry_dir) / secid_type / fs_path
-        if full_path.exists():
+        # Defense in depth: confirm the joined path stays inside the registry
+        # tree even if a hostile segment slipped past the check above.
+        full_path = _contained_path(registry_dir, Path(registry_dir) / secid_type / fs_path)
+        if full_path and full_path.exists():
             try:
                 data = json.loads(full_path.read_text())
                 key = build_namespace_key(data)
@@ -180,9 +220,12 @@ def load_type_info(registry_dirs: list[str], secid_type: str) -> Optional[dict]:
     lazy mode, where the full type index isn't pre-built. Also used by
     list_all_types() to assemble the /api/v1/types response.
     """
+    if _reject_unsafe_segment(secid_type):
+        logger.warning(f"Rejected unsafe type: {secid_type!r}")
+        return None
     for registry_dir in registry_dirs:
-        type_file = Path(registry_dir) / f"{secid_type}.json"
-        if type_file.exists():
+        type_file = _contained_path(registry_dir, Path(registry_dir) / f"{secid_type}.json")
+        if type_file and type_file.exists():
             try:
                 return json.loads(type_file.read_text())
             except json.JSONDecodeError as e:

--- a/python/resolver.py
+++ b/python/resolver.py
@@ -8,7 +8,7 @@ import json
 import re
 from typing import Optional
 
-from registry_loader import SECID_TYPES
+from registry_loader import SECID_TYPES, _reject_unsafe_segment
 from storage import Store
 
 # Format metadata fields lifted from child data to top-level result
@@ -212,6 +212,12 @@ def _match_namespace(store: Store, secid_type: str, path: str,
 
     Returns (namespace, remaining_name) or (None, None).
     """
+    # Boundary check: reject traversal/absolute/NUL before any candidate
+    # namespace reaches the lazy loader's filesystem join. Returning
+    # (None, None) flows into the existing not_found path — no error oracle.
+    if _reject_unsafe_segment(path):
+        return None, None
+
     segments = path.split("/")
     best_namespace = None
     best_name = None

--- a/python/test_smoke.py
+++ b/python/test_smoke.py
@@ -342,3 +342,78 @@ def test_cross_source_search_no_registry():
     from storage import create_store
     store = create_store("memory")
     assert _cross_source_search(store, "advisory", "CVE-2021-44228", None) == []
+
+
+# ---------------------------------------------------------------------------
+# Path-traversal containment (F-05-01 regression)
+# ---------------------------------------------------------------------------
+
+
+def test_reject_unsafe_segment():
+    """The segment guard rejects traversal/absolute/NUL but allows dotted labels."""
+    from registry_loader import _reject_unsafe_segment
+    assert _reject_unsafe_segment("a/../b") is True
+    assert _reject_unsafe_segment("../etc") is True
+    assert _reject_unsafe_segment("/etc/passwd") is True
+    assert _reject_unsafe_segment("a\\b") is True
+    assert _reject_unsafe_segment("a\x00b") is True
+    # Legitimate: dots inside a label are fine; only '..' *segments* are rejected.
+    assert _reject_unsafe_segment("redhat.com") is False
+    assert _reject_unsafe_segment("legislation.gov.uk/advisories") is False
+    assert _reject_unsafe_segment("a..b") is False
+    assert _reject_unsafe_segment(None) is False
+
+
+def test_contained_path(tmp_path):
+    """_contained_path returns an in-tree path but None for an escape."""
+    from registry_loader import _contained_path
+    base = tmp_path / "registry"
+    (base / "advisory" / "com").mkdir(parents=True)
+    legit = base / "advisory" / "com" / "redhat.json"
+    legit.write_text("{}")
+    assert _contained_path(str(base), legit) == legit.resolve()
+    secret = tmp_path / "secret.json"
+    secret.write_text("{}")
+    escape = base / "advisory" / "com" / "redhat" / ".." / ".." / ".." / ".." / "secret.json"
+    assert _contained_path(str(base), escape) is None
+
+
+def _make_registry(tmp_path):
+    """Minimal registry with one legit namespace + a secret file OUTSIDE the root."""
+    import json
+    base = tmp_path / "registry"
+    (base / "advisory" / "com").mkdir(parents=True)
+    (base / "advisory" / "com" / "redhat.json").write_text(json.dumps({
+        "type": "advisory", "namespace": "redhat.com", "match_nodes": [],
+    }))
+    secret = tmp_path / "secret.json"
+    secret.write_text(json.dumps({
+        "type": "advisory", "namespace": "secret.internal", "data": "TOPSECRET",
+    }))
+    return str(base), secret
+
+
+def test_load_single_blocks_traversal(tmp_path):
+    """A traversal namespace must not read a .json outside the registry root."""
+    from registry_loader import load_single
+    from storage import create_store
+    reg, _secret = _make_registry(tmp_path)
+    store = create_store("memory")
+    # Legit namespace still loads (the fix must not break normal use).
+    assert load_single(store, [reg], "advisory", "redhat.com") is not None
+    # Traversal to the out-of-tree secret returns None (not the secret).
+    assert load_single(store, [reg], "advisory", "redhat.com/../../../../secret") is None
+    # The secret's content never entered the store.
+    assert all("TOPSECRET" not in (store.get(k) or "") for k in store.keys())
+
+
+def test_resolve_traversal_is_not_found(tmp_path):
+    """End-to-end: a traversal query resolves to not-found, never the secret."""
+    import json
+    from resolver import resolve
+    from storage import create_store
+    reg, _secret = _make_registry(tmp_path)
+    store = create_store("memory")
+    resp = resolve(store, "secid:advisory/redhat.com/../../../../secret", registry_dirs=[reg])
+    assert resp["status"] != "found"
+    assert "TOPSECRET" not in json.dumps(resp)


### PR DESCRIPTION
## Finding
**F-05-01 (HIGH)** from the 2026-06 security audit. `registry_loader.load_single()` builds a filesystem path from the untrusted `secid` query (`Path(registry_dir)/<type>/<reversed-dns>/<subpath>.json`) with no containment. `pathlib`'s `/` join does **not** collapse `..`, so:

```
?secid=advisory/x/../../../../etc/passwd  →  /etc/passwd.json
```

escapes the registry tree — an arbitrary-`.json` read (e.g. other tenants' private overlays) plus a filesystem existence/readability oracle. Remote-**unauthenticated** on the shipped `--host 0.0.0.0` / no-auth defaults, on the default lazy-load path.

## Fix (two layers, fail closed)
- **`_reject_unsafe_segment()`** — rejects `..` path segments, absolute paths, backslashes, and NUL at the resolver boundary (`_match_namespace`) and in `load_single`/`load_type_info`. Returns `(None, None)` / `None`, which flows into the existing not-found path (no error oracle).
- **`_contained_path()`** — after building the path, `resolve()`s both it and the registry root and requires containment; applied at all three filesystem sinks (`load_single`, `build_type_index`, `load_type_info`). Fails closed on escape/resolution error.

Legitimate dotted namespaces (`redhat.com`, `legislation.gov.uk`) are unaffected — only `..` *segments* are rejected, not dots within a label.

## Tests
4 regression tests added (`_reject_unsafe_segment`, `_contained_path`, `load_single` traversal block, end-to-end `resolve` not-found + secret-never-read). Full suite: **32 passed**.

## Notes
- Also closes the latent sibling **F-05-02** (the `build_type_index`/`load_type_info` joins) via the same `_contained_path` guard.
- Backward-compatible: no API/behavior change for valid queries.

Generated from the audit patch `PATCHES/01-path-traversal-containment.patch.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)