### PR TITLE
fix: validate resolved URL scheme/authority in _substitute_url_template (F-07-01)

### DIFF
--- a/python/resolver.py
+++ b/python/resolver.py
@@ -6,6 +6,7 @@ walk the match_nodes tree, and return the result.
 
 import json
 import re
+import urllib.parse
 from typing import Optional
 
 from registry_loader import SECID_TYPES
@@ -22,7 +23,34 @@ def _add_format_metadata(result: dict, data: dict) -> None:
             result[field] = data[field]
 
 
-def _substitute_url_template(template: str, child_data: dict, captured_input: str) -> str:
+_ALLOWED_URL_SCHEMES = ("https", "http")
+
+
+def _validate_resolved_url(template: str, url: str) -> Optional[str]:
+    """Return url unless substitution changed the template's scheme/authority.
+
+    The open-redirect primitive (F-07-01) is the resolved host/scheme changing.
+    Read the template's literal authority by neutralizing {placeholders}, then
+    require the assembled URL's scheme + netloc to match. Path/query content on
+    the template's own host is left intact, so identifiers that legitimately
+    contain ':' etc. are unaffected. Returns None (caller drops to a
+    description-only result) on a scheme/host change; non-absolute templates
+    have no authority to enforce and pass through.
+    """
+    tpl = urllib.parse.urlsplit(re.sub(r"\{[^}]*\}", "x", template))
+    if not tpl.netloc:
+        return url
+    res = urllib.parse.urlsplit(url)
+    if res.scheme not in _ALLOWED_URL_SCHEMES:
+        return None
+    if res.scheme != tpl.scheme:
+        return None
+    if res.netloc != tpl.netloc:
+        return None
+    return url
+
+
+def _substitute_url_template(template: str, child_data: dict, captured_input: str) -> Optional[str]:
     """Substitute {var} placeholders in a URL template.
 
     Two substitution modes coexist:
@@ -61,11 +89,13 @@ def _substitute_url_template(template: str, child_data: dict, captured_input: st
     # Mode 2: implicit {id} default
     variables.setdefault("id", captured_input)
 
-    # Apply substitution
+    # Apply substitution. Values are kept verbatim — identifiers legitimately
+    # contain ':' and other reserved chars; the authority check below (not
+    # encoding) is what prevents an open redirect.
     url = template
     for name, value in variables.items():
         url = url.replace("{" + name + "}", value)
-    return url
+    return _validate_resolved_url(template, url)
 
 
 def resolve(store: Store, secid_query: str, registry_dirs: list[str] = None) -> dict:
@@ -306,10 +336,14 @@ def _build_node_result(node: dict, subpath: Optional[str], version: Optional[str
                         if child.get("weight"):
                             result["weight"] = child["weight"]
                         url_template = child_data.get("url")
-                        if url_template:
+                        resolved_url = (
+                            _substitute_url_template(url_template, child_data, subpath)
+                            if url_template else None
+                        )
+                        if resolved_url:
                             # URL-bearing result: substitute {var} placeholders;
                             # do NOT include `data` block (canonical contract).
-                            result["url"] = _substitute_url_template(url_template, child_data, subpath)
+                            result["url"] = resolved_url
                             _add_format_metadata(result, child_data)
                         else:
                             # Description-only result: include `data` block
@@ -336,8 +370,12 @@ def _build_node_result(node: dict, subpath: Optional[str], version: Optional[str
                         if child.get("weight"):
                             result["weight"] = child["weight"]
                         url_template = child_data.get("url")
-                        if url_template:
-                            result["url"] = _substitute_url_template(url_template, child_data, version)
+                        resolved_url = (
+                            _substitute_url_template(url_template, child_data, version)
+                            if url_template else None
+                        )
+                        if resolved_url:
+                            result["url"] = resolved_url
                             _add_format_metadata(result, child_data)
                         else:
                             _add_format_metadata(result, child_data)
@@ -567,10 +605,12 @@ def _cross_source_search(
                 if child.get("weight"):
                     result["weight"] = child["weight"]
                 url_template = child_data.get("url")
-                if url_template:
-                    result["url"] = _substitute_url_template(
-                        url_template, child_data, search_term
-                    )
+                resolved_url = (
+                    _substitute_url_template(url_template, child_data, search_term)
+                    if url_template else None
+                )
+                if resolved_url:
+                    result["url"] = resolved_url
                     _add_format_metadata(result, child_data)
                 results.append(result)
                 # One child match per source-level node is enough; don't

--- a/python/test_smoke.py
+++ b/python/test_smoke.py
@@ -342,3 +342,25 @@ def test_cross_source_search_no_registry():
     from storage import create_store
     store = create_store("memory")
     assert _cross_source_search(store, "advisory", "CVE-2021-44228", None) == []
+
+
+# ---------------------------------------------------------------------------
+# Resolved-URL authority validation (F-07-01)
+# ---------------------------------------------------------------------------
+
+
+def test_substitute_drops_authority_injection():
+    """A value that changes the template's host/scheme yields None (dropped)."""
+    from resolver import _substitute_url_template
+    assert _substitute_url_template("https://{id}.example.com/", {}, "evil.com") is None
+    assert _substitute_url_template("https://{id}/path", {}, "evil.com") is None
+
+
+def test_substitute_preserves_reserved_chars_on_same_host():
+    """Reserved chars (e.g. ':') in a path-position ID are preserved, not mangled,
+    and the result is returned because the host is unchanged."""
+    from resolver import _substitute_url_template
+    assert (
+        _substitute_url_template("https://access.redhat.com/errata/{id}", {}, "RHSA-2024:1234")
+        == "https://access.redhat.com/errata/RHSA-2024:1234"
+    )


### PR DESCRIPTION
## Finding
**F-07-01** — the **Server-API (Python) half** of the resolver-layer URL-validation, mirroring the Worker fix in SecID-Service#17. Closes Patch 06 across both resolvers.

`_substitute_url_template` substituted query-derived values into a registry URL template via raw `str.replace` with no validation. Latent today (registry templates keep placeholders in path position), but if a template placed a placeholder in the authority, a crafted identifier could steer the resolved host/scheme (open redirect).

## Fix
`_substitute_url_template` now returns `Optional[str]`: it re-parses the assembled URL and returns `None` unless the **scheme + netloc match the template's literal authority** (read by neutralizing `{placeholders}`). The three callers (`#subpath`, `@version`, cross-source) drop to a description-only result on `None`.

Values are kept **verbatim** — no `quote()` encoding — so identifiers that contain reserved chars (e.g. `RHSA-2024:1234`) are preserved. (Same lesson as #17, where blanket encoding broke the colon case.)

## Tests
2 new tests: authority-injection dropped (`https://{id}.example.com/`, `https://{id}/path` → None) and reserved-char preservation on the same host. The 6 existing `_substitute_url_template` tests still pass. **Full suite: 30 passed.**

Generated from `PATCHES/06-resolver-url-validation.patch.md` (Server-API half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)