### PR TITLE
Make the self-host server safe-by-default; add ReDoS input cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,25 @@ Update loading uses git to detect changes:
 # Pull latest registry data
 cd /path/to/SecID && git pull
 
-# Tell the server to reload changes
-curl -X POST http://localhost:8000/admin/reload
+# Tell the server to reload changes. /admin/reload is gated by a dedicated
+# reload token — set SECID_RELOAD_TOKEN (or --reload-token) when starting the
+# server, then send it in the X-Reload-Token header. With no token configured
+# the endpoint is disabled (returns 401).
+curl -X POST http://localhost:8000/admin/reload -H "X-Reload-Token: $SECID_RELOAD_TOKEN"
 ```
 
 Or run with `--watch` to auto-detect file changes.
+
+## Security & Exposure Defaults
+
+This reference server is **safe-by-default**:
+
+- **Binds to loopback (`127.0.0.1`) by default.** To serve other hosts, pass `--host 0.0.0.0` explicitly — and only behind a trusted network or reverse proxy. Front it with TLS so the reload token isn't sent in cleartext.
+- **`/admin/reload` is disabled unless you set a reload token** (`SECID_RELOAD_TOKEN` / `--reload-token`, sent as the `X-Reload-Token` header), compared in constant time. The token is scoped to reload only — give any future admin endpoint its own token rather than widening this one. The read path (`/api/v1/resolve`, `/api/v1/types`, `/mcp`) is anonymous by design.
+- **CORS is off by default.** No `Access-Control-Allow-Origin` header is sent unless you allowlist origins with `--cors-origin <origin>` (repeatable) or `SECID_CORS_ORIGINS` (comma-separated).
+- **Untrusted input is length-capped** before it reaches registry regexes (a ReDoS bound; real SecIDs are well under it).
+
+> **Upgrading from an earlier build?** The old defaults were `--host 0.0.0.0` and an unauthenticated `/admin/reload`. After this change you must (a) pass `--host 0.0.0.0` to keep listening on all interfaces, (b) set a reload token to use `/admin/reload` at all, and (c) pass `--cors-origin` if browser clients call the API cross-origin.
 
 ## API Compatibility
 

--- a/python/resolver.py
+++ b/python/resolver.py
@@ -25,6 +25,20 @@ def _add_format_metadata(result: dict, data: dict) -> None:
 
 _ALLOWED_URL_SCHEMES = ("https", "http")
 
+# ReDoS runtime bound. Registry-authored regexes (patterns[], variables.*.extract)
+# run against attacker-controlled input on every request via Python `re` — no RE2
+# backing, no timeout. Capping input length is the minimal stopgap: catastrophic
+# backtracking is super-linear in input size, so a hard cap bounds worst-case CPU.
+# FastAPI's `secid: str = Query(...)` is otherwise UNBOUNDED. (RE2 is the robust
+# follow-up; see audit Patch 09.)
+MAX_SECID_QUERY_CHARS = 1024  # whole query; real SecIDs are < 200 chars
+MAX_REGEX_INPUT = 256         # per-component (name / subpath / version / search term)
+
+
+def _too_long_for_regex(*values: Optional[str]) -> bool:
+    """True if any value exceeds the per-component ReDoS bound (None is fine)."""
+    return any(v is not None and len(v) > MAX_REGEX_INPUT for v in values)
+
 
 def _validate_resolved_url(template: str, url: str) -> Optional[str]:
     """Return url unless substitution changed the template's scheme/authority.
@@ -100,6 +114,10 @@ def _substitute_url_template(template: str, child_data: dict, captured_input: st
 
 def resolve(store: Store, secid_query: str, registry_dirs: list[str] = None) -> dict:
     """Resolve a SecID string. Returns the API response envelope."""
+    # ReDoS guard (see MAX_SECID_QUERY_CHARS): reject pathologically long input
+    # before any regex runs. FastAPI's Query(...) does not bound length itself.
+    if len(secid_query) > MAX_SECID_QUERY_CHARS:
+        return _error(secid_query[:MAX_SECID_QUERY_CHARS], "Query too long")
     secid_query = secid_query.strip()
 
     # Strip scheme
@@ -276,6 +294,13 @@ def _walk_match_nodes(nodes: list, name: str, subpath: Optional[str],
                        namespace: str, ns_data: dict) -> list[dict]:
     """Walk the match_nodes tree to find matching entries."""
     results = []
+
+    # ReDoS guard: a legitimate component is far under MAX_REGEX_INPUT, so
+    # refusing to run the registry regex on an over-long name/subpath/version
+    # (treated as no-match) bounds worst-case backtracking without affecting
+    # any valid resolution.
+    if _too_long_for_regex(name, subpath, version):
+        return results
 
     # If we have a name, match it against top-level nodes
     if name:
@@ -568,7 +593,7 @@ def _cross_source_search(
     (rare in current registry data) are not traversed by cross-source.
     The Worker's equivalent behavior is the canonical reference.
     """
-    if not search_term:
+    if not search_term or _too_long_for_regex(search_term):
         return []
 
     results: list[dict] = []

--- a/python/secid_server.py
+++ b/python/secid_server.py
@@ -22,6 +22,7 @@ Serves:
 from __future__ import annotations
 
 import argparse
+import hmac
 import json
 import logging
 import os
@@ -29,7 +30,7 @@ import sys
 from dataclasses import dataclass, field
 from typing import Optional
 
-from fastapi import FastAPI, Query
+from fastapi import Depends, FastAPI, Header, HTTPException, Query, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
@@ -64,6 +65,13 @@ class ServerConfig:
     storage_type: str = "memory"
     storage_kwargs: dict = field(default_factory=dict)
     load_mode: str = "lazy"
+    # Reload-specific token (NOT a master key). Required for POST /admin/reload;
+    # None/empty => the endpoint is disabled (always 401). Set via --reload-token
+    # or the SECID_RELOAD_TOKEN environment variable.
+    reload_token: Optional[str] = None
+    # Explicit CORS allowlist. Empty => CORS middleware is not added at all
+    # (no Access-Control-Allow-Origin header; browsers block cross-origin reads).
+    cors_origins: list[str] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -91,12 +99,41 @@ def create_app(config: ServerConfig) -> FastAPI:
         version="0.1.0",
     )
 
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],
-        allow_methods=["GET", "POST"],
-        allow_headers=["*"],
-    )
+    # CORS is opt-in: with no configured origins the middleware is not added,
+    # so no Access-Control-Allow-Origin header is sent (browsers block
+    # cross-origin reads). Operators opt in via --cors-origin / SECID_CORS_ORIGINS.
+    if config.cors_origins:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=config.cors_origins,
+            allow_methods=["GET", "POST"],
+            allow_headers=["*"],
+        )
+        logger.info(f"CORS enabled for origins: {config.cors_origins}")
+    else:
+        logger.info("CORS disabled (no --cors-origin configured)")
+
+    def require_reload_token(x_reload_token: Optional[str] = Header(default=None)) -> None:
+        """Gate POST /admin/reload behind its dedicated reload token.
+
+        Fail closed: 401 when no reload token is configured server-side, or when
+        the presented X-Reload-Token header does not match. Constant-time compare
+        avoids leaking the token via timing. This dependency guards ONLY the
+        reload capability — do not reuse it for other admin routes; give each its
+        own SECID_<CAP>_TOKEN.
+        """
+        expected = config.reload_token
+        if not expected:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="/admin/reload disabled: no reload token configured "
+                       "(set SECID_RELOAD_TOKEN / --reload-token)",
+            )
+        if not x_reload_token or not hmac.compare_digest(x_reload_token, expected):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="invalid or missing X-Reload-Token",
+            )
 
     @app.get("/api/v1/resolve")
     async def api_resolve(
@@ -130,9 +167,9 @@ def create_app(config: ServerConfig) -> FastAPI:
         """
         return JSONResponse(content={"types": list_all_types(config.registry_dirs)})
 
-    @app.post("/admin/reload")
+    @app.post("/admin/reload", dependencies=[Depends(require_reload_token)])
     async def admin_reload():
-        """Reload registry data (after git pull)."""
+        """Reload registry data (after git pull). Requires X-Reload-Token."""
         from registry_loader import update_load
         count = update_load(store, config.registry_dirs)
         return {"reloaded": count}
@@ -214,6 +251,12 @@ def _try_mount_mcp(app: FastAPI, store, config: ServerConfig) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _default_cors_origins() -> list[str]:
+    """CORS allowlist from SECID_CORS_ORIGINS (comma-separated). Empty if unset."""
+    raw = os.environ.get("SECID_CORS_ORIGINS", "")
+    return [o.strip() for o in raw.split(",") if o.strip()]
+
+
 def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="SecID Self-Hosted Server")
     parser.add_argument(
@@ -225,7 +268,22 @@ def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     parser.add_argument("--memcached-url", default="localhost:11211")
     parser.add_argument("--sqlite-path", default=":memory:")
     parser.add_argument("--load", default="lazy", choices=["lazy", "bulk"])
-    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument(
+        "--host", default="127.0.0.1",
+        help="Interface to bind. Defaults to loopback. Pass 0.0.0.0 to expose on "
+             "all interfaces (only behind a trusted network/proxy + a reload token).",
+    )
+    parser.add_argument(
+        "--reload-token", default=os.environ.get("SECID_RELOAD_TOKEN"),
+        help="Token required for POST /admin/reload (or SECID_RELOAD_TOKEN env). "
+             "Scoped to reload only. Unset => /admin/reload disabled (401).",
+    )
+    parser.add_argument(
+        "--cors-origin", action="append", default=_default_cors_origins(),
+        dest="cors_origins", metavar="ORIGIN",
+        help="Browser origin allowed to call the API cross-origin (repeatable, "
+             "or SECID_CORS_ORIGINS comma-separated). Default: none.",
+    )
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"])
     return parser.parse_args(argv)
@@ -281,9 +339,20 @@ def main(argv: Optional[list[str]] = None) -> int:
         storage_type=args.storage,
         storage_kwargs=_build_storage_kwargs(args),
         load_mode=args.load,
+        reload_token=args.reload_token,
+        cors_origins=args.cors_origins,
     )
 
     app = create_app(config)
+
+    if args.host not in ("127.0.0.1", "localhost", "::1") and not args.reload_token:
+        logger.warning(
+            "Binding to %s exposes this server on all interfaces. /admin/reload "
+            "is disabled (no SECID_RELOAD_TOKEN set) but the read API is "
+            "world-reachable. Set --reload-token to enable reload, and place it "
+            "behind a trusted network/proxy.",
+            args.host,
+        )
 
     import uvicorn
     logger.info(f"Starting SecID server on {args.host}:{args.port}")

--- a/python/test_smoke.py
+++ b/python/test_smoke.py
@@ -439,3 +439,88 @@ def test_resolve_traversal_is_not_found(tmp_path):
     resp = resolve(store, "secid:advisory/redhat.com/../../../../secret", registry_dirs=[reg])
     assert resp["status"] != "found"
     assert "TOPSECRET" not in json.dumps(resp)
+
+
+# ---------------------------------------------------------------------------
+# Safe-by-default server: reload token, CORS allowlist (F-06-01, F-06-02, F-06-03)
+# ---------------------------------------------------------------------------
+
+
+def _app_with(**kwargs):
+    return create_app(ServerConfig(registry_dirs=[], storage_type="memory", **kwargs))
+
+
+def test_admin_reload_disabled_without_token():
+    """No reload token configured => POST /admin/reload fails closed with 401,
+    before any reload runs. This is the F-06-01 fix (was unauth)."""
+    client = TestClient(_empty_app())
+    resp = client.post("/admin/reload")
+    assert resp.status_code == 401
+    assert "no reload token" in resp.json()["detail"].lower()
+
+
+def test_admin_reload_rejects_wrong_token():
+    """Token configured, missing/wrong X-Reload-Token => 401."""
+    client = TestClient(_app_with(reload_token="s3cret"))
+    assert client.post("/admin/reload").status_code == 401  # missing header
+    assert client.post("/admin/reload", headers={"X-Reload-Token": "wrong"}).status_code == 401
+
+
+def test_admin_reload_accepts_correct_token():
+    """Token configured + matching X-Reload-Token => handler runs (200)."""
+    client = TestClient(_app_with(reload_token="s3cret"))
+    resp = client.post("/admin/reload", headers={"X-Reload-Token": "s3cret"})
+    assert resp.status_code == 200
+    assert "reloaded" in resp.json()
+
+
+def test_read_endpoints_need_no_token():
+    """The read path stays anonymous by design — the token guards only reload."""
+    client = TestClient(_app_with(reload_token="s3cret"))
+    assert client.get("/health").status_code == 200
+    assert client.get("/api/v1/resolve?secid=secid:advisory/x").status_code == 200
+
+
+def test_cors_disabled_by_default():
+    """No --cors-origin configured => no Access-Control-Allow-Origin header."""
+    client = TestClient(_empty_app())
+    resp = client.get("/health", headers={"Origin": "https://evil.example"})
+    assert "access-control-allow-origin" not in {k.lower() for k in resp.headers}
+
+
+def test_cors_enabled_for_configured_origin():
+    """An explicitly allowlisted origin gets the CORS header; others do not."""
+    client = TestClient(_app_with(cors_origins=["https://good.example"]))
+    ok = client.get("/health", headers={"Origin": "https://good.example"})
+    assert ok.headers.get("access-control-allow-origin") == "https://good.example"
+
+
+# ---------------------------------------------------------------------------
+# ReDoS runtime bound (F-03-02): cap untrusted input fed to registry regexes
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_rejects_oversize_query():
+    """A query past MAX_SECID_QUERY_CHARS returns a clean error before any regex."""
+    from resolver import resolve, MAX_SECID_QUERY_CHARS
+    from storage import create_store
+    store = create_store("memory")
+    resp = resolve(store, "secid:advisory/" + "a" * (MAX_SECID_QUERY_CHARS + 10))
+    assert resp["status"] == "error"
+    assert "too long" in resp["message"].lower()
+
+
+def test_oversize_query_via_http():
+    """The cap is enforced through the HTTP layer too (FastAPI Query is unbounded)."""
+    from resolver import MAX_SECID_QUERY_CHARS
+    client = TestClient(_empty_app())
+    resp = client.get("/api/v1/resolve?secid=secid:advisory/" + "a" * (MAX_SECID_QUERY_CHARS + 10))
+    assert resp.status_code == 200  # envelope contract: always 200
+    assert resp.json()["status"] == "error"
+
+
+def test_too_long_for_regex_helper():
+    """Per-component bound: None and short values pass; an over-long one trips."""
+    from resolver import _too_long_for_regex, MAX_REGEX_INPUT
+    assert not _too_long_for_regex(None, "cve", "CVE-2021-44228")
+    assert _too_long_for_regex("a" * (MAX_REGEX_INPUT + 1))


### PR DESCRIPTION
## Summary

`SecID-Server-API` is the reference / self-host server (for users without Cloudflare). It previously **bound to `0.0.0.0`**, exposed an **unauthenticated `POST /admin/reload`**, sent **CORS `*`**, and fed **unbounded query input** to registry regexes. This hardens all four to safe-by-default.

Audit reference: SecID-2026-06-14-claude-skill (findings F-06-01, F-06-02, F-06-03, F-03-02).

## Safe-by-default server (`python/secid_server.py`)

| Finding | Before | After |
|---|---|---|
| **F-06-03** | `--host 0.0.0.0` default | `--host 127.0.0.1` default; `0.0.0.0` is an explicit opt-in with a loud startup warning |
| **F-06-01** | `POST /admin/reload` unauthenticated | Gated by a **dedicated reload token** (`SECID_RELOAD_TOKEN` / `--reload-token`, header `X-Reload-Token`), `hmac.compare_digest`. **Fails closed**: no token configured → 401 |
| **F-06-02** | `allow_origins=["*"]` | CORS **opt-in**: no `--cors-origin` / `SECID_CORS_ORIGINS` → middleware not added at all |

The reload token is **scoped to reload only** — deliberately not a master key. A future admin endpoint should get its own `SECID_<CAP>_TOKEN` rather than widening this one. The read path (`/api/v1/resolve`, `/api/v1/types`, `/mcp`) stays **anonymous by design**.

## ReDoS runtime bound (`python/resolver.py`)

Registry-authored regexes run against attacker-controlled input on every request via Python `re` — no RE2, no timeout — and FastAPI's `secid: str = Query(...)` was **unbounded**. `resolve()` now rejects queries over `MAX_SECID_QUERY_CHARS` (1024), and over-long components (`MAX_REGEX_INPUT`, 256) are treated as **no-match** rather than truncated — so worst-case backtracking is bounded **without changing any valid resolution** (real SecIDs are < 200 chars). RE2 is the robust follow-up; this cap is the minimal stopgap. (F-03-02)

## Tests
+9 regression tests, **43 pass** (`pytest test_smoke.py`): reload 401-without-token / 401-wrong-token / 200-correct-token, read-path-needs-no-token, CORS off-by-default / on-when-allowlisted, oversize-query rejection (direct + HTTP), and the component-bound helper.

## ⚠️ Intentional backward-compat break (documented in README)
Existing self-hosters must now: **(a)** pass `--host 0.0.0.0` to keep listening on all interfaces, **(b)** set a reload token to use `/admin/reload` at all, **(c)** pass `--cors-origin` if browser clients call cross-origin. A new "Security & Exposure Defaults" README section + an upgrade note cover this.

## Notes for review
- No real pattern in the registry is catastrophic today (all anchored) — both the CORS and ReDoS changes are defense-in-depth / missing-control fixes.
- Token-in-header is only as safe as the transport: if `0.0.0.0` is used, front with TLS. Consider rate-limiting `/admin/reload`.
- Simpler alternative to a token (noted, not taken): bind `/admin/*` to loopback only or replace it with a CLI/`SIGHUP` refresh. The token path was chosen because it was the requested design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)